### PR TITLE
Add missing CareKit Card examples

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		703A7E6F2644DCEA007D8979 /* CustomContactsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703A7E6E2644DCEA007D8979 /* CustomContactsViewController.swift */; };
 		703A7E7D2645761B007D8979 /* MyContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703A7E7C2645761B007D8979 /* MyContactView.swift */; };
 		703A7E822645769B007D8979 /* MyContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703A7E812645769B007D8979 /* MyContactViewController.swift */; };
+		703A7E9526458B71007D8979 /* CustomFeaturedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703A7E9426458B71007D8979 /* CustomFeaturedContentView.swift */; };
 		707CC714254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC715254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC716254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
@@ -142,6 +143,7 @@
 		703A7E6E2644DCEA007D8979 /* CustomContactsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomContactsViewController.swift; sourceTree = "<group>"; };
 		703A7E7C2645761B007D8979 /* MyContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyContactView.swift; sourceTree = "<group>"; };
 		703A7E812645769B007D8979 /* MyContactViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyContactViewController.swift; sourceTree = "<group>"; };
+		703A7E9426458B71007D8979 /* CustomFeaturedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFeaturedContentView.swift; sourceTree = "<group>"; };
 		705B22BE25E2C1A700C472AC /* OCKWatchSample Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "OCKWatchSample Extension.entitlements"; sourceTree = "<group>"; };
 		707CC710254DA91900116728 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		707CC712254DA91900116728 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				70F79B232642C3B600731C46 /* CustomInstructionsTaskViewController.swift */,
+				703A7E9426458B71007D8979 /* CustomFeaturedContentView.swift */,
 				70F79B362642DBC100731C46 /* CustomButtonLogTaskViewController.swift */,
 				70F79B602644325B00731C46 /* LogValueView.swift */,
 				70F79B652644339E00731C46 /* LogValue.swift */,
@@ -626,6 +629,7 @@
 				70F79B192641FB7F00731C46 /* ImagePicker.swift in Sources */,
 				7036E4BF256DA089006E9A3C /* Login.swift in Sources */,
 				7036E517256F2413006E9A3C /* Profile.swift in Sources */,
+				703A7E9526458B71007D8979 /* CustomFeaturedContentView.swift in Sources */,
 				70F79B372642DBC100731C46 /* CustomButtonLogTaskViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OCKSample/MainTabs/Care/CareViewController.swift
+++ b/OCKSample/MainTabs/Care/CareViewController.swift
@@ -111,30 +111,51 @@ class CareViewController: OCKDailyPageViewController {
             case .failure(let error): print("Error: \(error)")
             case .success(let tasks):
 
-                // Add a non-CareKit view into the list
-                let tipTitle = "Benefits of exercising"
-                let tipText = "Learn how activity can promote a healthy pregnancy."
-
                 // Only show the tip view on the current date
                 if Calendar.current.isDate(date, inSameDayAs: Date()) {
+                    // Add a non-CareKit view into the list
+                    let tipTitle = "Benefits of exercising"
+                    let tipText = "Learn how activity can promote a healthy pregnancy."
+                    
                     let tipView = TipView()
                     tipView.headerView.titleLabel.text = tipTitle
                     tipView.headerView.detailLabel.text = tipText
                     tipView.imageView.image = UIImage(named: "exercise.jpg")
                     listViewController.appendView(tipView, animated: false)
+                    
+                    //New a different way of showing card
+                    let featuredContent = CustomFeaturedContentView()
+                    featuredContent.imageView.image = UIImage(named: "exercise.jpg")
+                    featuredContent.label.text = tipTitle
+                    featuredContent.label.textColor = .white
+                    listViewController.appendView(featuredContent, animated: false)
                 }
 
-                if #available(iOS 14, *), let walkTask = tasks.first(where: { $0.id == "steps" }) {
+                if #available(iOS 14, *) {
+                    if let walkTask = tasks.first(where: { $0.id == "steps" }) {
 
-                    let view = NumericProgressTaskView(
-                        task: walkTask,
-                        eventQuery: OCKEventQuery(for: date),
-                        storeManager: self.storeManager)
-                        .padding([.vertical], 10)
+                        let view = NumericProgressTaskView(
+                            task: walkTask,
+                            eventQuery: OCKEventQuery(for: date),
+                            storeManager: self.storeManager)
+                            .padding([.vertical], 10)
 
-                    listViewController.appendViewController(view.formattedHostingController(), animated: false)
+                        listViewController.appendViewController(view.formattedHostingController(), animated: false)
+                    
+                        //New
+                        let labeledValueView = LabeledValueTaskView(
+                            task: walkTask,
+                            eventQuery: OCKEventQuery(for: date),
+                            storeManager: self.storeManager)
+                            .padding([.vertical], 10)
+                        listViewController.appendViewController(labeledValueView.formattedHostingController(), animated: true)
+                    }
+                    
+                    //New
+                    let linkView = LinkView(title: Text("University of Kentucky"), links: [.website("https://www.engr.uky.edu/research-faculty/departments/computer-science", title: "Computer Science")])
+                    listViewController.appendViewController(linkView.formattedHostingController(), animated: true)
                 }
-                
+
                 if let stretchTask = tasks.first(where: { $0.id == "stretch" }) {
                     let stretchCard = CustomInstructionsTaskViewController(task: stretchTask, eventQuery: .init(for: date),
                                                                  storeManager: self.storeManager)
@@ -142,7 +163,7 @@ class CareViewController: OCKDailyPageViewController {
                     stretchCard.detailHTML = .init(html: "Stretching is good for you!")
                     listViewController.appendViewController(stretchCard, animated: false)
                 }
-
+                
                 // Since the kegel task is only scheduled every other day, there will be cases
                 // where it is not contained in the tasks array returned from the query.
                 if let kegelsTask = tasks.first(where: { $0.id == "kegels" }) {
@@ -160,6 +181,10 @@ class CareViewController: OCKDailyPageViewController {
                         storeManager: self.storeManager)
 
                     listViewController.appendViewController(doxylamineCard, animated: false)
+                    
+                    //New
+                    let stretchCardGrid = OCKGridTaskViewController(task: doxylamineTask, eventQuery: .init(for: date), storeManager: self.storeManager)
+                    listViewController.appendViewController(stretchCardGrid, animated: true)
                 }
 
                 // Create a card for the nausea task if there are events for it on this day.

--- a/OCKSample/MainTabs/Care/Custom/CustomFeaturedContentView.swift
+++ b/OCKSample/MainTabs/Care/Custom/CustomFeaturedContentView.swift
@@ -1,0 +1,33 @@
+//
+//  CustomFeaturedContentView.swift
+//  OCKSample
+//
+//  Created by Corey Baker on 5/7/21.
+//  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
+//
+
+import UIKit
+import CareKit
+import CareKitUI
+
+/// A simple subclass to take control of what CareKit already gives us.
+class CustomFeaturedContentView: OCKFeaturedContentView {
+    override init(imageOverlayStyle: UIUserInterfaceStyle = .unspecified) {
+        super.init(imageOverlayStyle: imageOverlayStyle)
+        
+        //Need to become a delegate so we know when view is tapped.
+        self.delegate = self
+    }
+}
+
+/// Need to conform to delegate in order to be delegated to.
+extension CustomFeaturedContentView: OCKFeaturedContentViewDelegate {
+    //ToDo: Make this either open up a link relevant to your app or do something different when tapped.
+    //It cannot be the same is what is already happening.
+    func didTapView(_ view: OCKFeaturedContentView) {
+        //When tapped, open a URL.
+        if let url = URL(string: "https://uknowledge.uky.edu/cgi/viewcontent.cgi?article=1008&context=nutrisci_etds") {
+            UIApplication.shared.open(url)
+        }
+    }
+}


### PR DESCRIPTION
Adds the rest of the CareKit cards and shows how to use them.

Cards that were missing:

- [x] OCKFeaturedContentView
- [x] OCKGridTaskViewController 
- [x] LinkView (SwiftUI)
- [x] LabeledValueTaskView (SwiftUI)